### PR TITLE
c376ff0405074c34b950daf5cb83d18b-an-owners-file-is-submitted-by-redhat-6446f1115-redhat-redhat-missing-prefix-c376ff0405074c34b950daf5cb83d18b-0.0.1

### DIFF
--- a/charts/redhat/redhat/missing-prefix-c376ff0405074c34b950daf5cb83d18b/OWNERS
+++ b/charts/redhat/redhat/missing-prefix-c376ff0405074c34b950daf5cb83d18b/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: missing-prefix-c376ff0405074c34b950daf5cb83d18b
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: komish
+vendor:
+  label: redhat
+  name: "Red Hat"


### PR DESCRIPTION
Testing CI from workstation